### PR TITLE
Add HomeScreen widget test

### DIFF
--- a/test/presentation/home_screen_test.dart
+++ b/test/presentation/home_screen_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:clean_arch_flutter_template/presentation/module/home/view/home_screen.dart';
+import 'package:clean_arch_flutter_template/presentation/injector/injector.dart';
+
+void main() {
+  setUpAll(() {
+    configureDependencies();
+  });
+
+  testWidgets('HomeScreen displays Home Screen text', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: HomeScreen()));
+    expect(find.text('Home Screen'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add widget test for HomeScreen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68639ae297e483319756c597cb37ce6e